### PR TITLE
buferSubData post-check does not use byteOffset of TypedArrays

### DIFF
--- a/src/augment-api.js
+++ b/src/augment-api.js
@@ -1017,7 +1017,8 @@ export function augmentAPI(ctx, nameOfClass, options = {}) {
       const elemSize = isDataView ? 1 : src.BYTES_PER_ELEMENT;
       const copySize = copyLength * elemSize;
       const arrayBuffer = src.buffer ? src.buffer : src;
-      const newView = new Uint8Array(arrayBuffer, srcOffset * elemSize, copySize);
+      const viewOffset = src.byteOffset || 0;
+      const newView = new Uint8Array(arrayBuffer, viewOffset + srcOffset * elemSize, copySize);
       view.set(newView, dstByteOffset);
     },
 


### PR DESCRIPTION
In buferSubData post-check take into account TypedArray's byteOffset when calculating offset for copying the buffer data into bufferToIndices Map.

The fix is using the same logic as #21 did for the same issue in bufferData post-check.

