### PR TITLE
check eboType with vertCount on drawElements

### DIFF
--- a/src/augment-api.js
+++ b/src/augment-api.js
@@ -826,12 +826,12 @@ export function augmentAPI(ctx, nameOfClass, options = {}) {  // eslint-disable-
     const uniformSamplerInfos = programToUniformSamplerValues.get(sharedState.currentProgram);
     const uniformSamplersMap = new Map();
     for (const {type, values, name} of uniformSamplerInfos) {
-      let value = values[0];
-      let uniformSamplerType = uniformSamplersMap.get(value);
-      if(!uniformSamplerType){
-        uniformSamplersMap.set(value,type);
-      }else{
-        if(uniformSamplerType !== type){
+      const value = values[0];
+      const uniformSamplerType = uniformSamplersMap.get(value);
+      if (!uniformSamplerType){
+        uniformSamplersMap.set(value, type);
+      } else {
+        if (uniformSamplerType !== type){
           reportFunctionError(ctx, funcName, args, `Two textures of different types can't use the same sampler location. uniform ${getUniformTypeInfo(type).name} ${getUniformElementName(name, values.length, 0)} is not ${getUniformTypeInfo(uniformSamplerType).name}`);
           return;
         }

--- a/src/check-attributes-buffer-overflow.js
+++ b/src/check-attributes-buffer-overflow.js
@@ -6,6 +6,7 @@ import {
   glTypeToTypedArray,
   isWebGL2,
   isBuiltIn,
+  getEBOTypeByVertCount,
 } from './utils.js';
 
 const VERTEX_ATTRIB_ARRAY_DIVISOR = 0x88FE;
@@ -18,6 +19,11 @@ function getLastUsedIndexForDrawElements(gl, funcName, startOffset, vertCount, i
   const elementBuffer = gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING);
   if (!elementBuffer) {
     errors.push('No ELEMENT_ARRAY_BUFFER bound');
+    return undefined;
+  }
+  const eboType = getEBOTypeByVertCount(vertCount);
+  if(eboType !== indexType){
+    errors.push(`the vert count is ${vertCount}, the type of this values in the element array buffer should be: ${glEnumToString(eboType)}, but the current ELEMENT_ARRAY_BUFFER ${getWebGLObjectString(elementBuffer)} sets ${glEnumToString(indexType)}`);
     return undefined;
   }
   const bytesPerIndex = getBytesPerValueForGLType(indexType);

--- a/src/check-attributes-buffer-overflow.js
+++ b/src/check-attributes-buffer-overflow.js
@@ -22,7 +22,7 @@ function getLastUsedIndexForDrawElements(gl, funcName, startOffset, vertCount, i
     return undefined;
   }
   const eboType = getEBOTypeByVertCount(vertCount);
-  if(eboType !== indexType){
+  if (eboType !== indexType){
     errors.push(`the vert count is ${vertCount}, the type of this values in the element array buffer should be: ${glEnumToString(eboType)}, but the current ELEMENT_ARRAY_BUFFER ${getWebGLObjectString(elementBuffer)} sets ${glEnumToString(indexType)}`);
     return undefined;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -276,6 +276,23 @@ export function getBytesPerValueForGLType(type) {
   return glTypeToSizeMap.get(type) || 0;
 }
 
+const glTypeToLimitMap = new Map([
+  [UNSIGNED_BYTE , 256],
+  [UNSIGNED_BYTE , 65536],
+  [UNSIGNED_BYTE , 4294967296],
+]);
+
+export function getEBOTypeByVertCount(vertCount) {
+  let type;
+  for(let v of glTypeToLimitMap ) {
+    if(vertCount <= v[1]){
+      type = v[0];
+      break;
+    }
+  }
+  return type;
+}
+
 const glTypeToTypedArrayMap = new Map([
   [UNSIGNED_BYTE,  Uint8Array],
   [UNSIGNED_SHORT, Uint16Array],

--- a/src/utils.js
+++ b/src/utils.js
@@ -284,8 +284,8 @@ const glTypeToLimitMap = new Map([
 
 export function getEBOTypeByVertCount(vertCount) {
   let type;
-  for(let v of glTypeToLimitMap ) {
-    if(vertCount <= v[1]){
+  for (const v of glTypeToLimitMap ) {
+    if (vertCount <= v[1]){
       type = v[0];
       break;
     }

--- a/test/tests/unrenderable-texture-tests.js
+++ b/test/tests/unrenderable-texture-tests.js
@@ -392,7 +392,7 @@ describe('unrenderable texture tests', () => {
       gl.drawArrays(gl.POINTS, 0, 1);
     });
 
-    it('test two texture type in same sampler location',() => {
+    it('test two texture type in same sampler location', () => {
       const {gl, tagObject} = contexts;
       const vs = `
       void main() {
@@ -415,8 +415,8 @@ describe('unrenderable texture tests', () => {
 
       const cubeLoc = gl.getUniformLocation(prg, 'u_cubeTex');
       const texLoc = gl.getUniformLocation(prg, 'u_tex');
-      gl.uniform1i(cubeLoc,0);
-      gl.uniform1i(texLoc,0);
+      gl.uniform1i(cubeLoc, 0);
+      gl.uniform1i(texLoc, 0);
 
       const cubeTex = gl.createTexture();
       tagObject(cubeTex, 'u_cubeTex');
@@ -439,19 +439,19 @@ describe('unrenderable texture tests', () => {
       assertThrowsWith(() => {
         gl.drawArrays(gl.POINTS, 0, 1);
       }, [/mip level 1 does not exist/]);
-      
-      
-      
+
+
+
       const tex = gl.createTexture();
       tagObject(tex, 'u_tex');
       gl.bindTexture(gl.TEXTURE_2D, tex);
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 4, 4, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-      
-      
+
+
       assertThrowsWith(() => {
         gl.drawArrays(gl.POINTS, 0, 1);
       }, [/mip level 1 does not exist/]);
-      
+
       gl.generateMipmap(gl.TEXTURE_2D);
       gl.generateMipmap(gl.TEXTURE_CUBE_MAP);
 


### PR DESCRIPTION
I usually make mistake with the ebo type :(
demo:
mistake:http://106.55.102.172:1234/test/drawelements/
normal:http://106.55.102.172:1234/4_advance_opengl/10.4_asteroids_instance/

The test sample on ther way.