### PR TITLE
Fix Uncaught TypeError when setting an undefined uniform sampler

### DIFF
--- a/src/augment-api.js
+++ b/src/augment-api.js
@@ -1052,6 +1052,9 @@ export function augmentAPI(ctx, nameOfClass, options = {}) {  // eslint-disable-
   }
 
   function recordSamplerValues(webglUniformLocation, newValues) {
+    if (!webglUniformLocation) {
+        return;
+    }
     const name = locationsToNamesMap.get(webglUniformLocation);
     const uniformInfos = programToUniformInfoMap.get(webglState.currentProgram);
     const {index, type, values} = uniformInfos.get(name);


### PR DESCRIPTION
Affects webgl-lint@1.11.3.

```
Uncaught TypeError: uniformInfos.get(...) is undefined
    recordSamplerValues https://greggman.github.io/webgl-lint/webgl-lint.js:2653
    markUniformSetAndRecordSamplerValue https://greggman.github.io/webgl-lint/webgl-lint.js:2647
    funcName https://greggman.github.io/webgl-lint/webgl-lint.js:3426
    <anonymous> http://127.0.0.1:5500/minimal.html:81
```

Test case: https://gist.github.com/dzil123/c282452ceffcaf710b33de853052b931
